### PR TITLE
Claude test: naming規約に基づいてカラー・transition・translate変数をリネーム

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,19 +1,19 @@
 :root {
-  --main-bg-color:#fffef8;
-  --sub-bg-color:#f8fafa;
-  --tx-bg-color:#ffffffa9;
-  --orange-bg-color:#ea773d66;
-  --tx-bg-green-color:#88a890;
-  --shadow-color:#06280627;
+  --bg-primary:#fffef8;
+  --bg-secondary:#f8fafa;
+  --bg-overlay:#ffffffa9;
+  --bg-accent:#ea773d66;
+  --bg-muted:#88a890;
+  --shadow-base:#06280627;
 }
 
 :root {
-  --main-color:#444943;
-  --sub-color:#fffefb;
-  --title-color:#658C6F;
-  --accent-green-color:#309E66;
-  --accent-orange-color:#ef9365;
-  --small-color:#b5b5b5;
+  --text-primary:#444943;
+  --text-inverse:#fffefb;
+  --text-title:#658C6F;
+  --primary-00:#309E66;
+  --highlight-00:#ef9365;
+  --text-muted:#b5b5b5;
 }
 
 :root {
@@ -48,7 +48,7 @@
   src: url("../../../font/Kokoro.woff2") format("woff2");
 }
 body {
-  background-color: var(--main-bg-color);
+  background-color: var(--bg-primary);
   min-width: 360px;
   height: auto;
   min-height: 700px;
@@ -80,7 +80,7 @@ img.category.is-show {
 }
 
 * {
-  color: var(--main-color);
+  color: var(--text-primary);
   font-family: "higuregothic";
   scroll-behavior: smooth;
   font-size: 1.125rem;
@@ -122,7 +122,7 @@ ul, ol {
   width: 100%;
 }
 .l-site-header.is-open .l-global-nav {
-  border-left: dotted 4px var(--accent-green-color);
+  border-left: dotted 4px var(--primary-00);
   overflow-x: scroll;
 }
 .l-site-header.is-open .l-hamburger span:nth-child(1) {
@@ -164,7 +164,7 @@ ul, ol {
   height: 100vh;
   width: 350px;
   padding-top: 100px;
-  background-color: var(--main-bg-color);
+  background-color: var(--bg-primary);
 }
 
 img.l-logo-in-navmenu {
@@ -174,13 +174,13 @@ img.l-logo-in-navmenu {
 
 .has-child a {
   font-size: 1.25rem;
-  color: var(--accent-green-color);
+  color: var(--primary-00);
   font-family: "utsukushi";
   transition: 0.2s ease;
 }
 
 .l-sub-nav a {
-  color: var(--main-color);
+  color: var(--text-primary);
   font-family: "higuregothic";
   font-size: 0.9375rem;
   margin-bottom: 10px;
@@ -198,7 +198,7 @@ img.l-logo-in-navmenu {
   width: 5px;
   height: 5px;
   border-radius: 5px;
-  background-color: var(--title-color);
+  background-color: var(--text-title);
   position: absolute;
   top: 50%;
   left: 0;
@@ -214,7 +214,7 @@ img.l-logo-in-navmenu {
 }
 
 a.l-go-top {
-  color: var(--main-color);
+  color: var(--text-primary);
   font-size: 0.9375rem;
 }
 
@@ -248,7 +248,7 @@ a.l-go-top {
     opacity: 0.5;
   }
   .l-sub-nav li a:hover {
-    color: var(--title-color);
+    color: var(--text-title);
   }
   .l-sub-nav li:hover a::before {
     width: 30px;
@@ -301,7 +301,7 @@ a.l-go-top {
   bottom: 0;
   left: 0;
   z-index: 9999;
-  background-color: var(--main-bg-color);
+  background-color: var(--bg-primary);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -332,7 +332,7 @@ a.l-go-top {
   display: block;
   width: 0%;
   height: 100%;
-  background-color: var(--accent-green-color);
+  background-color: var(--primary-00);
   transition: var(--transition-slow);
 }
 .l-loading .l-load-inner .l-load-count {
@@ -542,7 +542,7 @@ a.l-go-top {
   display: block;
   width: 60px;
   height: 1px;
-  background-color: var(--accent-green-color);
+  background-color: var(--primary-00);
   transition: 0.4s ease;
 }
 .l-hamburger span:nth-child(1) {

--- a/sass/abstracts/mixins/_slide-in.scss
+++ b/sass/abstracts/mixins/_slide-in.scss
@@ -1,7 +1,7 @@
 @use "../variables/translate" as *;
 @use "../variables/transition" as *;
 
-@mixin slide-in($start-trs: $trs-right, $duration: $transition-base){
+@mixin slide-in($start-trs: $translate-right, $duration: $transition-lg){
     opacity: 0;
     transform: $start-trs;
     pointer-events: none;
@@ -9,17 +9,17 @@
 
     &.is-show, &.is-open, .is-open & {
         opacity: 1;
-        transform: $trs-reset;
+        transform: $translate-reset;
         pointer-events: auto;
     }
 }
 
-// 何も書かなければ $transition-base (.4s)
+// 何も書かなければ $transition-lg (.4s)
 // .c-fixed-link {
 //   @include slide-in-right;
 // }
 
 // サッと出したいときは .2s
 // .l-global-nav {
-//   @include slide-in-right($transition-early);
+//   @include slide-in-right($transition-sm);
 // }

--- a/sass/abstracts/variables/_color.scss
+++ b/sass/abstracts/variables/_color.scss
@@ -1,16 +1,16 @@
 :root{
-	--main-bg-color:#fffef8;
-	--sub-bg-color:#f8fafa;
-	--tx-bg-color:#ffffffa9;
-	--orange-bg-color:#ea773d66;
-	--tx-bg-green-color:#88a890;
-	--shadow-color:#06280627;
+	--bg-primary:#fffef8;
+	--bg-secondary:#f8fafa;
+	--bg-overlay:#ffffffa9;
+	--bg-accent:#ea773d66;
+	--bg-muted:#88a890;
+	--shadow-base:#06280627;
 }
 :root{
-	--main-color:#444943;
-	--sub-color:#fffefb;
-	--title-color:#658C6F;
-	--accent-green-color:#309E66;
-	--accent-orange-color:#ef9365;
-	--small-color:#b5b5b5;
+	--text-primary:#444943;
+	--text-inverse:#fffefb;
+	--text-title:#658C6F;
+	--primary-00:#309E66;
+	--highlight-00:#ef9365;
+	--text-muted:#b5b5b5;
 }

--- a/sass/abstracts/variables/_hambuger-span.scss
+++ b/sass/abstracts/variables/_hambuger-span.scss
@@ -5,7 +5,7 @@
   width: $width;
   height: $height;
   background-color: $color;
-  transition: $transition-base;
+  transition: $transition-lg;
 }
 
 @mixin hamburger-lines-init($w1, $w2, $w3, $top1, $top2, $top3, $l1, $l2, $l3) {

--- a/sass/abstracts/variables/_transition.scss
+++ b/sass/abstracts/variables/_transition.scss
@@ -1,3 +1,3 @@
-$transition-base: .4s ease;
-$transition-early: .2s ease;
-$transition-slow: .3s ease;
+$transition-sm: .2s ease;
+$transition-md: .3s ease;
+$transition-lg: .4s ease;

--- a/sass/abstracts/variables/_translate.scss
+++ b/sass/abstracts/variables/_translate.scss
@@ -1,5 +1,5 @@
-$trs-right: translateX(100%);
-$trs-left: translateX(-100%);
-$trs-top: translateY(-100%);
-$trs-bottom: translateY(100%);
-$trs-reset: translate(0, 0);
+$translate-right: translateX(100%);
+$translate-left: translateX(-100%);
+$translate-top: translateY(-100%);
+$translate-bottom: translateY(100%);
+$translate-reset: translate(0, 0);

--- a/sass/foundation/_base.scss
+++ b/sass/foundation/_base.scss
@@ -1,7 +1,7 @@
 @use '../abstracts/index' as *;
 
 body{
-	background-color: var(--main-bg-color);
+	background-color: var(--bg-primary);
 	min-width: 360px;
 	@include height-size($minHeight: 700px);
 }

--- a/sass/foundation/_reboot.scss
+++ b/sass/foundation/_reboot.scss
@@ -1,7 +1,7 @@
 @use "../abstracts/index" as *;
 
 *{
-	color: var(--main-color);
+	color: var(--text-primary);
 	font-family: 'higuregothic';
 	scroll-behavior: smooth;
 	font-size: to-rem(18);

--- a/sass/layout/_header.scss
+++ b/sass/layout/_header.scss
@@ -2,12 +2,12 @@
 
 .l-site-header{
 	@include fixed-position(0, 0, null, null, 900);
-	@include slide-in($trs-right, $transition-base);
+	@include slide-in($translate-right, $transition-lg);
 	width: 100%;
 
 	&.is-open{
 		.l-global-nav{
-			border-left: dotted 4px var(--accent-green-color);
+			border-left: dotted 4px var(--primary-00);
 			overflow-x: scroll;
 		}
 		
@@ -28,11 +28,11 @@
 
 .l-global-nav{
 	@include fixed-position(0, 0, null, null, null);
-	@include slide-in($trs-right, $transition-base);
+	@include slide-in($translate-right, $transition-lg);
 	@include height-size(100vh);
 	width: 350px;
 	padding-top: 100px;
-	background-color: var(--main-bg-color);
+	background-color: var(--bg-primary);
 }
 
 img.l-logo-in-navmenu{
@@ -43,15 +43,15 @@ img.l-logo-in-navmenu{
 .has-child{
 	a{
 		font-size: to-rem(20);
-		color: var(--accent-green-color);
+		color: var(--primary-00);
 		font-family: 'utsukushi';
-		transition:  $transition-early;
+		transition:  $transition-sm;
 	}
 }
 
 .l-sub-nav{
 	a{
-		color: var(--main-color);
+		color: var(--text-primary);
 		font-family: 'higuregothic';
 		font-size: to-rem(15);
 		margin-bottom: 10px;
@@ -63,7 +63,7 @@ img.l-logo-in-navmenu{
 		a{
 			margin-bottom: 7px;
 			margin-left: 40px;
-			transition: $transition-early;
+			transition: $transition-sm;
 
 			&::before{
 				content: '';
@@ -71,12 +71,12 @@ img.l-logo-in-navmenu{
 				width: 5px;
 				height: 5px;
 				border-radius: 5px;
-				background-color: var(--title-color);
+				background-color: var(--text-title);
 				position: absolute;
 				top: 50%;
 				left: 0;
 				transform: translateY(-50%);
-				transition: $transition-slow;
+				transition: $transition-md;
 			}
 		}
 	}
@@ -88,7 +88,7 @@ img.l-logo-in-navmenu{
 }
 
 a.l-go-top{
-	color: var(--main-color);
+	color: var(--text-primary);
 	font-size: to-rem(15);
 }
 
@@ -131,7 +131,7 @@ a.l-go-top{
 		li{
 			a{
 				&:hover{
-					color: var(--title-color);
+					color: var(--text-title);
 				}
 			}
 			&:hover{

--- a/sass/layout/_loading.scss
+++ b/sass/layout/_loading.scss
@@ -3,7 +3,7 @@
 .l-loading{
 	width: 100%;
     @include fixed-full(9999);
-	background-color: var(--main-bg-color);
+	background-color: var(--bg-primary);
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -36,7 +36,7 @@
                 display: block;
                 width: 0%;
                 height: 100%;
-                background-color: var(--accent-green-color);
+                background-color: var(--primary-00);
                 transition: var(--transition-slow);
             }
         }

--- a/sass/layout/_main.scss
+++ b/sass/layout/_main.scss
@@ -7,7 +7,7 @@
 	@include height-size(100vh, Heights(pc-min-height), Heights(pc-max-height));
 	@include relative-position;
 	margin-inline: auto;
-	transition: $transition-slow;
+	transition: $transition-md;
 
     svg{
         &.fv-svg{
@@ -15,7 +15,7 @@
 			@include absolute-position(52%,63%);
             z-index: z-index(5);
             opacity: 0;
-	        transition:  $transition-base;
+	        transition:  $transition-lg;
 
             &.is-ready {
                 opacity: 1;

--- a/sass/object/component/_button.scss
+++ b/sass/object/component/_button.scss
@@ -2,7 +2,7 @@
 
 .c-fixed-link{
 	@include fixed-position(null, 6px, 0, null, 100);
-	@include slide-in($trs-right, $transition-base);
+	@include slide-in($translate-right, $transition-lg);
 	width: fluid(150, 250, 1024, 2000);
 	aspect-ratio: 250 / 170;
 	height: auto;

--- a/sass/object/component/_hamburger.scss
+++ b/sass/object/component/_hamburger.scss
@@ -13,7 +13,7 @@
 	span{
 		position: absolute;
 		left: 0;
-		@include hamburger-lines(60px,1px,var(--accent-green-color));
+		@include hamburger-lines(60px,1px,var(--primary-00));
 		@include hamburger-lines-init(
 			70px, 60px, 50px,
 			0, 14px, 28px,


### PR DESCRIPTION
## 概要

goodpractices.design/guidelines/naming の命名規則に則り、SCSS変数名をリネームしました。

## 変更内容

- **カラー変数**を機能ベースの命名へ変更（--main-bg-color → --bg-primary、--accent-green-color → --primary-00 など全12変数）
- **transition変数**をサイズスケールへ変更（$transition-base → $transition-lg、$transition-early → $transition-sm、$transition-slow → $transition-md）
- **translate変数**の略語をフルスペルへ変更（$trs-right → $translate-right など全5変数）

## 対象ファイル

- sass/abstracts/variables/_color.scss / _transition.scss / _translate.scss
- sass/abstracts/mixins/_slide-in.scss
- sass/abstracts/variables/_hambuger-span.scss
- sass/foundation/_base.scss / _reboot.scss
- sass/layout/_header.scss / _loading.scss / _main.scss
- sass/object/component/_button.scss / _hamburger.scss
- css/style.css（コンパイル済み）

## Claude試運用メモ

命名規則の記事を参照し「どの変数をどう変えるべきか教えて」→「カラーから着手・使用箇所も全て変更して」→「transition/translateも変更して」という流れで依頼。変数の定義ファイルと全使用箇所を自動で洗い出し、一括リネームしました。

Generated with Claude Code
