### PR TITLE
Claude test: SVGアニメーションのバグ修正とJSの堅牢性向上

### DIFF
--- a/js/script1.js
+++ b/js/script1.js
@@ -45,18 +45,20 @@ const fv = document.querySelector('.l-fv');
 const footer = document.querySelector('footer');
 const hamburger = document.getElementById('l-hamburger');
 const nav = document.querySelector('.l-global-nav');
-const navLinks = nav.querySelectorAll('a');
 const fixedLink = document.querySelector('.c-fixed-link');
 
 hamburger.addEventListener('click', () => {
 	header.classList.toggle('is-open')
 });
 
-navLinks.forEach(link => {
-	link.addEventListener('click', () => {
-		header.classList.remove('is-open')
-	})
-});
+if (nav) {
+	const navLinks = nav.querySelectorAll('a');
+	navLinks.forEach(link => {
+		link.addEventListener('click', () => {
+			header.classList.remove('is-open')
+		})
+	});
+}
 
 window.addEventListener('scroll', () => {
 	const lFvBottom = fv.getBoundingClientRect().bottom;
@@ -83,18 +85,20 @@ window.addEventListener('scroll', () => {
 const slides = document.querySelectorAll('.slide');
 let current = 0;
 
-slides[current].classList.remove('is-active');
-setTimeout(() => {
-	slides[current].classList.add('is-active')
-},
-50);
-
-setInterval(() => {
+if (slides.length > 0) {
 	slides[current].classList.remove('is-active');
-	current = (current + 1) % slides.length;
-	slides[current].classList.add('is-active')
-},
-5000);
+	setTimeout(() => {
+		slides[current].classList.add('is-active')
+	},
+	50);
+
+	setInterval(() => {
+		slides[current].classList.remove('is-active');
+		current = (current + 1) % slides.length;
+		slides[current].classList.add('is-active')
+	},
+	5000);
+}
 
 window.addEventListener('load', () => {
 	const lFvSvg = document.querySelector('.fv-svg');
@@ -118,6 +122,7 @@ const svgObserver = new IntersectionObserver(entries => {
 	entries.forEach(entry => {
 		if (entry.isIntersecting) {
 			entry.target.classList.add('is-show')
+			svgObserver.unobserve(entry.target)
 		}
 	})
 },
@@ -160,6 +165,7 @@ const observer = new IntersectionObserver(entries => {
 	entries.forEach(entry => {
 		if (entry.isIntersecting) {
 			entry.target.classList.add('is-show')
+			observer.unobserve(entry.target)
 		}
 	})
 },
@@ -208,18 +214,20 @@ if (questions.length && answers.length) {
 }
 const toggleBtn = document.getElementById('activity-toggle');
 const pastArea = document.getElementById('activity-past');
-const icon = toggleBtn.querySelector('.open-icon');
-const label = toggleBtn.querySelector('.look-label');
-toggleBtn.addEventListener('click', () => {
-	const isOpen = pastArea.classList.toggle('is-open');
-	if (isOpen) {
-		icon.textContent = '−';
-		label.textContent = '閉じる'
-	} else {
-		icon.textContent = '＋';
-		label.textContent = '全て見る(他9件)'
-	}
-});
+if (toggleBtn) {
+	const icon = toggleBtn.querySelector('.open-icon');
+	const label = toggleBtn.querySelector('.look-label');
+	toggleBtn.addEventListener('click', () => {
+		const isOpen = pastArea.classList.toggle('is-open');
+		if (isOpen) {
+			icon.textContent = '−';
+			label.textContent = '閉じる'
+		} else {
+			icon.textContent = '＋';
+			label.textContent = '全て見る(他9件)'
+		}
+	});
+}
 
 window.history.scrollRestoration = 'manual';
 window.scrollTo(0, 0);

--- a/sass/layout/_main.scss
+++ b/sass/layout/_main.scss
@@ -15,10 +15,10 @@
 			@include absolute-position(52%,63%);
             z-index: z-index(5);
             opacity: 0;
-	        transition:  $transition-lg;
 
             &.is-ready {
                 opacity: 1;
+                transition: opacity $transition-lg;
             }
         }
     }


### PR DESCRIPTION
## 概要

SVGアニメーションの不具合修正と、JavaScriptの堅牢性向上を行いました。

## 変更内容

### バグ修正 - SVGアニメーション逆向き問題（_main.scss）

`transition` がベース状態に書かれていたため、CSS適用時にブラウザが opacity 1→0 のアニメーションを実行していた（反対向きに動く問題）。
`transition: opacity` を `.is-ready` 状態に移動し、表示時（0→1）のみアニメーションするよう修正。

### JS修正 - nullチェック追加（script1.js）

- `slides` が0件のページで TypeError が発生し、SVGアニメーションの登録も止まっていた → `if (slides.length > 0)` で囲む
- `nav` が存在しないページでエラー → `if (nav)` で囲む
- `toggleBtn` が存在しないページでエラー → `if (toggleBtn)` で囲む

### JS修正 - unobserve追加（script1.js）

`svgObserver` と `observer`（js-split用）がトリガー後も監視し続けていた。
`fadeObserver` と同様に、アニメーション発火後に `unobserve` するよう修正。

## Claude試運用メモ

「JSのアニメーションにミスがないかチェックして」と依頼。コードを静的解析し、3種類の問題を発見・修正しました。

Generated with Claude Code
