### PR TITLE
refactor: ローディングのpx値をto-rem()に統一

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -295,7 +295,7 @@ ul, ol {
   }
 }
 .l-loading {
-  width: 100%;
+  width: 100vw;
   position: fixed;
   top: 0;
   right: 0;
@@ -317,11 +317,11 @@ ul, ol {
   align-items: center;
   justify-content: center;
   font-size: 1.25rem;
-  margin-bottom: 40px;
+  margin-bottom: 2.5rem;
 }
 .l-loading__text img {
-  height: 230px;
-  margin: 30px;
+  height: 14.375rem;
+  margin: 1.875rem;
 }
 .l-loading__text span {
   font-family: "higuregothic";
@@ -329,7 +329,7 @@ ul, ol {
 
 .l-loading__bar {
   width: 100vw;
-  height: 2px;
+  height: 0.125rem;
   overflow: hidden;
 }
 
@@ -342,7 +342,7 @@ ul, ol {
 }
 
 .l-loading__count {
-  margin-top: 50px;
+  margin-top: 3.125rem;
   font-size: 1.5625rem;
   font-family: "higuregothic";
 }
@@ -355,7 +355,7 @@ ul, ol {
     margin-block: auto;
   }
   .l-loading__text img {
-    height: 150px;
+    height: 9.375rem;
   }
 }
 .l-fv {

--- a/sass/layout/_loading.scss
+++ b/sass/layout/_loading.scss
@@ -1,7 +1,7 @@
 @use "../abstracts/index" as *;
 
 .l-loading{
-	width: 100%;
+	width: 100vw;
 	@include fixed-full(9999);
 	background-color: var(--bg-primary);
 	display: flex;
@@ -17,12 +17,12 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: to-rem(20px);
-	margin-bottom: 40px;
+	font-size: to-rem(20);
+	margin-bottom: to-rem(40);
 
 	img{
-		height: 230px;
-		margin: 30px;
+		height:  to-rem(230);
+		margin: to-rem(30);
 	}
 
 	span{
@@ -32,7 +32,7 @@
 
 .l-loading__bar{
 	width: 100vw;
-	height: 2px;
+	height: to-rem(2);
 	overflow: hidden;
 }
 
@@ -45,8 +45,8 @@
 }
 
 .l-loading__count{
-	margin-top: 50px;
-	font-size: to-rem(25px);
+	margin-top: to-rem(50);
+	font-size: to-rem(25);
 	font-family: 'higuregothic';
 }
 
@@ -58,7 +58,7 @@
 		margin-block: auto;
 
 		img{
-			height: 150px;
+			height: to-rem(150);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `_loading.scss` の固定px値をすべて `to-rem()` に変換
- `width: 100%` → `width: 100vw` に修正