### PR TITLE
fix: h2のline-heightをfluid値に変更

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -160,7 +160,7 @@ h2 {
   font-family: "kokoro";
   font-size: clamp(1.5625rem, 1.3170347003rem + 0.9463722397vw, 2.5rem);
   letter-spacing: 0;
-  line-height: 4.0625rem;
+  line-height: clamp(2.5rem, 2.0908911672rem + 1.5772870662vw, 4.0625rem);
 }
 h2 span {
   font-family: "higuregothic";

--- a/sass/foundation/_base.scss
+++ b/sass/foundation/_base.scss
@@ -38,7 +38,7 @@ h2{
 	font-family: 'kokoro';
 	font-size: fluid(25, 40, 415, 2000);
 	letter-spacing: 0;
-	line-height: to-rem(65);
+	line-height: fluid( 40, 65, 415, 2000);
 
 	span{
 		font-family: 'higuregothic';


### PR DESCRIPTION
## Summary
- `h2` の `line-height` を `to-rem(65)` 固定値から `fluid(40, 65, 415, 2000)` に変更
- 全体の見出しがモバイル〜PCで行間がレスポンシブ対応（issue #161）

## Test plan
- [ ] 各セクションの見出しの行間が崩れていないこと
- [ ] モバイルで行間が詰まりすぎないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)