### PR TITLE
fix: FAQセクションの最大幅を1300remに修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1572,7 +1572,7 @@ p.p-member__intro {
 .l-faq {
   margin: 0 auto;
   padding: 0 1.875rem;
-  max-width: 125rem;
+  max-width: 81.25rem;
   width: 100%;
 }
 

--- a/sass/layout/_faq.scss
+++ b/sass/layout/_faq.scss
@@ -4,7 +4,7 @@
 .l-faq{
 	margin: 0 auto;
 	padding: 0 to-rem(30);
-	max-width: to-rem(2000);
+	max-width: to-rem(1300);
 	width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- `_faq.scss`: `.l-faq`の`max-width`を`to-rem(2000)`から`to-rem(1300)`に修正

## Test plan
- [ ] FAQセクションの表示幅が適切であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)