### PR TITLE
refactor: フッターサブナビのpadding-leftをfluid()に変更

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1933,10 +1933,12 @@ p.p-member__intro {
     margin: 1.25rem 0;
   }
   .p-footer__sub-nav {
-    padding-left: 1.875rem;
+    padding-left: clamp(0.625rem, 0.3365384615rem + 1.2307692308vw, 1.875rem);
     border-left: solid 0.0625rem var(--text-muted);
   }
   .p-footer__entry-link a p {
     margin: 1.875rem auto 0;
   }
 }
+
+/*# sourceMappingURL=style.css.map */

--- a/sass/object/project/_footer-section.scss
+++ b/sass/object/project/_footer-section.scss
@@ -175,7 +175,7 @@
     }
 
     .p-footer__sub-nav{
-        padding-left: to-rem(30);
+        padding-left: fluid( 10, 30, 375, 2000);
         border-left: solid to-rem(1) var(--text-muted);
     }
 


### PR DESCRIPTION
## Summary
- `_footer-section.scss` のSP時サブナビ `padding-left` を固定値から `fluid()` に変更

## Test plan
- [ ] フッターナビゲーションのSP表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)