### PR TITLE
feat: ナビゲーションリンクのフォントをkokoroに変更

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -277,7 +277,7 @@ ul, ol {
 }
 
 .l-nav__item > .l-nav__link {
-  font-family: "utsukushi";
+  font-family: "kokoro";
   text-align: center;
   transition: 0.2s ease;
   margin: clamp(1.875rem, 1.5865384615rem + 1.2307692308vw, 3.125rem) 0;

--- a/sass/layout/_header.scss
+++ b/sass/layout/_header.scss
@@ -48,7 +48,7 @@
 
 .l-nav__item{
 	& > .l-nav__link{
-		font-family: 'utsukushi';
+		font-family: 'kokoro';
 		text-align: center;
 		transition: $transition-sm;
 		margin: fluid( 30, 50, 375, 2000) 0;


### PR DESCRIPTION
## Summary
- `.l-nav__link` の `font-family` を `utsukushi` から `kokoro` に変更

## Test plan
- [ ] ヘッダーナビゲーションのフォント表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)