### PR TITLE
fix: フッターのアンカーリンクを新id属性に合わせて更新

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -21,8 +21,8 @@
 					<li class="p-footer__nav-item">
 						<a href="#members" class="p-footer__nav-category">メンバー紹介</a>
 						<ul class="p-footer__sub-nav">
-							<li><a href="#members">メンバーインタビュー</a></li>
-							<li><a href="#all-mem-list">AguRokkaメンバー紹介</a></li>
+							<li><a href="#l-member-list">AguRokkaメンバー紹介</a></li>
+							<li><a href="#l-interview">メンバーインタビュー</a></li>
 							<li><a href="#faq">よくあるご質問</a></li>
 						</ul>
 					</li>


### PR DESCRIPTION
## Summary
- `#members` → `#l-member-list` に更新
- `#all-mem-list` → `#l-interview` に更新
- リスト順を「AguRokkaメンバー紹介」→「メンバーインタビュー」に変更

## Test plan
- [ ] フッターのメンバー紹介リンクが正しいセクションに遷移すること
- [ ] フッターのメンバーインタビューリンクが正しいセクションに遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)