### PR TITLE
refactor: header.phpの旧ナビゲーションのコメントアウトを削除

### DIFF
--- a/header.php
+++ b/header.php
@@ -5,7 +5,6 @@
 			<span></span>
 			<span></span>
 		</button>
-
 		<nav class="l-global-nav">
 			<a href="index.php">
 				<img src="images/logo/agurokka_logo.webp" alt="AguRokkaのロゴ" class="l-global-nav__logo">
@@ -35,41 +34,5 @@
 				</li>
 			</ul>
 		</nav>
-		<!-- <nav class="l-global-nav">
-			<img src="images/logo/agurokka_logo.webp" alt="AguRokkaのロゴ" class="l-global-nav__logo">
-			<ul class="l-nav__list">
-				<li class="l-nav__item">
-					<a href="#about-us" class="l-nav__link">AguRokkaについて</a>
-					<ul class="l-nav__sub">
-						<li><a href="#about-us">AguRokkaとは</a></li>
-						<li><a href="#why-agurokka">AguRokkaの由来</a></li>
-					</ul>
-				</li>
-				<li class="l-nav__item">
-					<a href="#members" class="l-nav__link">メンバーについて</a>
-					<ul class="l-nav__sub">
-						<li><a href="#members">メンバーインタビュー</a></li>
-						<li><a href="#all-mem-list">AguRokkaメンバー紹介</a></li>
-						<li><a href="#faq">Q&A</a></li>
-					</ul>
-				</li>
-				<li class="l-nav__item">
-					<a href="#activity" class="l-nav__link">活動情報</a>
-					<ul class="l-nav__sub">
-						<li><a href="#activity">活動履歴</a></li>
-						<li><a href="#">トップへ戻る</a></li>
-					</ul>
-				</li>
-				<li class="l-nav__item">
-					<a href="https://docs.google.com/forms/d/1y0TlJKK-Ip5nqA4ef7zxUNKzVR2Dzr_bWXMSe7v3G1A/viewform?edit_requested=true" target="_blank" class="l-nav__entry-link" style="color: #ef9365;">入会フォームへ</a>
-				</li>
-				<li class="l-nav__item--sns">
-					<div class="l-nav__sns">
-						<a href="https://www.instagram.com/agurokka_kumamoto/" target="_blank" class="l-nav__sns-link"><img src="images/logo/Instagram_Glyph_Gradient.webp" alt="Instagramのアイコン" height="40"></a>
-						<a href="https://www.facebook.com/p/%E3%81%8F%E3%81%BE%E3%82%82%E3%81%A8%E8%BE%B2%E6%A5%AD%E5%A5%B3%E5%8F%B2%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%83%86%E3%82%A3%E3%83%BC-Agurokka-61551086036877/" target="_blank" class="l-nav__sns-link"><img src="images/logo/Facebook_Logo_Primary.webp" alt="Facebookのアイコン" width="auto" height="40"></a>
-					</div>
-				</li>
-			</ul>
-		</nav> -->
 	</div>
 </header>


### PR DESCRIPTION
## Summary
- コメントアウトされた旧 `<nav>` ブロック（37行）を削除
- 不要な空行を1行削除

## Test plan
- [ ] ヘッダーのナビゲーションが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)