### PR TITLE
refactor(loading): ローディングHTMLをloading.phpからfv.phpに移動

### DIFF
--- a/sections/fv.php
+++ b/sections/fv.php
@@ -1,3 +1,16 @@
+<div class="l-loading" id="l-loading">
+	<div class="l-loading__inner">
+		<p class="l-loading__text">
+			<span>一緒に未来ば</span>
+			<img src="images/logo/agurokka_logo.webp" alt="AguRokkaのロゴ">
+			<span>つくろっか。</span>
+		</p>
+		<div class="l-loading__bar">
+			<span class="l-loading__progress"></span>
+		</div>
+		<p class="l-loading__count" style="color: #309E66;"><span id="l-loadingCount" style="font-size: 50px; color: #309E66;">0</span>%</p>
+	</div>
+</div>
 <div class="l-fv">
 	<div class="l-fv__copy">
 		<!-- <div class="l-fv__copy-items">

--- a/sections/loading.php
+++ b/sections/loading.php
@@ -1,4 +1,4 @@
-<div class="l-loading" id="l-loading">
+<!-- <div class="l-loading" id="l-loading">
 	<div class="l-loading__inner">
 		<p class="l-loading__text">
 			<span>一緒に未来ば</span>
@@ -10,4 +10,4 @@
 		</div>
 		<p class="l-loading__count" style="color: #309E66;"><span id="l-loadingCount" style="font-size: 50px; color: #309E66;">0</span>%</p>
 	</div>
-</div>
+</div> -->


### PR DESCRIPTION
## Summary
- ローディング用HTMLを `sections/loading.php` から `sections/fv.php` に移動
- `sections/loading.php` の内容をコメントアウト

🤖 Generated with [Claude Code](https://claude.com/claude-code)